### PR TITLE
[PATCH]: add repro builds through submodules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,9 @@
 .idea
 cmake-*
 images
+CMakeCache.txt
+EnabledFeatures.txt
+CMakeFiles/
+cmake_install.cmake
+compile_commands.json
+Makefile

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "LibRaw-cmake"]
+	path = LibRaw-cmake
+	url = https://github.com/LibRaw/LibRaw-cmake.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,14 @@
 cmake_minimum_required(VERSION 3.25)
+
 project(cr3_converter)
 
-set(CMAKE_CXX_STANDARD 23)
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O0")
-#set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3")
-
-# Add link for libraw
-link_libraries(raw)
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED True)
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 add_executable(cr3_converter main.cpp)
+
+add_subdirectory(LibRaw-cmake)
+target_link_libraries(cr3_converter PRIVATE libraw::libraw)
+
+target_compile_options(cr3_converter PRIVATE -Wall -Wextra -O -g)

--- a/README.md
+++ b/README.md
@@ -2,6 +2,19 @@
 
 This project uses libraw to convert cr3 files to jpeg.
 
-You will need to install it yourself.
+## Building
 
-https://www.libraw.org/download#stable
+Clone the repo to your machine as such:
+
+```bash
+$ git clone --recurse-submodules https://github.com/sudokid-software/cr3_converter
+
+$ cd cr3_converter
+
+$ mkdir build
+
+$ cd build
+
+$ cmake ..
+```
+


### PR DESCRIPTION
Added the library as a submodule through cmake, hopefully makes building easier

Meaning this will be required to clone
`git clone --recurse-submodules https://github.com/sudokid-software/cr3_converter` 